### PR TITLE
Don't throw an exception when pygments fails to highlight.

### DIFF
--- a/src/infrastructure/markup/syntax/highlighter/pygments/PhutilDefaultSyntaxHighlighterEnginePygmentsFuture.php
+++ b/src/infrastructure/markup/syntax/highlighter/pygments/PhutilDefaultSyntaxHighlighterEnginePygmentsFuture.php
@@ -27,7 +27,10 @@ final class PhutilDefaultSyntaxHighlighterEnginePygmentsFuture
       return phutil_safe_html($body);
     }
 
-    throw new PhutilSyntaxHighlighterException($body, $status->getStatusCode());
+    // TODO(csilvers): remove this `return`, and go back to the throw,
+    // once epriestley has resolved https://admin.phacility.com/PHI1764
+    return id(new PhutilDefaultSyntaxHighlighter())->getHighlightFuture($this->source)->resolve();
+    // throw new PhutilSyntaxHighlighterException($body, $status->getStatusCode());
   }
 
 }


### PR DESCRIPTION
We have code that when pygments fails to highlight, we raise an
exception.  This exception is caught in
src/infrastructure/markup/syntax/engine/PhutilSyntaxHighlighterEngine.php,
at which point the engine moves to using the default syntax
highlighter instead.

But there's a bug whwere sometimes (when the http call returns right
away) the exception is thrown somewhere unexpected, where
PhutilSyntaxHighlighterEngine doesn't catch it properly.  epriestley
hsa promised a fix in https://admin.phacility.com/PHI1764, but without
a timeline.

This change works around the problem in the meantime, by just
short-circuiting the exception step.  We just go straight to
constructing the default highlighter ourselves if pygments gives an
error.

I don't know php at all, so I can't say for sure that this will work
-- perhaps it causes an import cycle (does php have such things?) or
the symbol isn't visible, or something like that. I don't know how to
tell.  I tried running the phabricator test suite but I couldn't get
the instructions at
/home/csilvers/khan/devtools/arcanist/src/init/init-library.php:12 to
work:
```
phabricator% arc unit
Exception
Unable to establish a connection to any database host (while trying "phabricator_config"). All masters and replicas are completely unreachable.

Exception: About to call mysql_connect(), but the PHP MySQL extension is not available!
(Run with `--trace` for a full exception trace.)

% arc --config-path=../arcanist/.arcconfig unit
Usage Exception: Unknown command '--config-path=../arcanist/.arcconfig'. Try 'arc help'.
```

Issue: https://admin.phacility.com/PHI1764

Test plan:
Fingers crossed